### PR TITLE
Update the browserslist config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # This is the [Browserslist](https://github.com/browserslist/browserslist) config for use in RVU products
 
-[This config is published to NPM](https://www.npmjs.com/package/@uswitch/browserslist-config) and can be used anywhere by simply adding `extends @uswitch/browserslist-config` to your browserslist config, the easiest way to use this config is to add the following to your package.json file
+[This config is published to NPM](https://www.npmjs.com/package/@uswitch/browserslist-config) and can be used anywhere by simply adding `extends @uswitch/browserslist-config` to your browserslist config. The easiest way to use this config is to add the following to your package.json file
 
 ```json
   "browserslist": [
@@ -9,16 +9,20 @@
 ```
 
 Current Support 
+
 ```
-  Chrome >= 43
-  iOS >= 8
-  Safari >= 8
+  Chrome >= 55
+  iOS  >= 9
+  Safari >= 9
   ie >= 11
-  Samsung >= 4
+  Samsung >= 11
+  Android >= 81
   Firefox ESR
   Firefox >= 52
-  Opera >= 53
-  Edge >= 14
+  Edge >= 90
+  Opera >= 62
+  OperaMini >= 4
+  UCAndroid >= 1
 ```
 
 [Supported browsers can be found on Notion](https://www.notion.so/rvu/Browser-support-4f8c037f60ef4245a84d36913215e079)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Current Support
   Edge >= 90
   Opera >= 62
   OperaMini >= 4
-  UCAndroid >= 1
+  UCAndroid >= 13
 ```
 
 [Supported browsers can be found on Notion](https://www.notion.so/rvu/Browser-support-4f8c037f60ef4245a84d36913215e079)

--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
 module.exports = [
-  "Chrome >= 43",
-  "iOS >= 8",
-  "Safari >= 8",
+  "Chrome >= 55",
+  "iOS  >= 9",
+  "Safari >= 9",
   "ie >= 11",
-  "Samsung >= 4",
+  "Samsung >= 11",
+  "Android >= 81",
   "Firefox ESR",
   "Firefox >= 52",
-  "Opera >= 53",
-  "Edge >= 14"
-]
+  "Edge >= 90",
+  "Opera >= 62",
+  "OperaMini >= 4",
+  "UCAndroid >= 13",
+];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/browserslist-config",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "RVU browserslist config",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
The browserslist config hasn't been updated since 2020, so I've run the numbers (using this [GA report](https://analytics.google.com/analytics/web/#/report/visitors-browser/a207299w265509p47160568/_u.date00=20221013&_u.date01=20230112) as a source) and updated it. 

Attached is a zip with the CSV files from GA and the script I used to analyse them

Once this PR is merged, I'll update [the Notion](https://www.notion.so/rvu/Browser-support-4f8c037f60ef4245a84d36913215e079) 

[analysis.zip](https://github.com/uswitch/browserslist-config/files/10665273/analysis.zip)
