### PR TITLE
Update Feb 25 with lower threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,13 @@
 Current Support
 
 ```
-  Safari >= 10.3
+  Safari >= 15.5
   iOS >= 10.3
-  Chrome >= 58
-  Samsung >= 11
-  Firefox ESR
-  Firefox >= 54
+  Chrome >= 109
+  Samsung >= 26
+  Firefox >= 115
   Edge >= 80
-  Android >= 58
+  Android >= 109
 ```
 
 [Supported browsers can be found on Notion](https://www.notion.so/rvu/Browser-support-4f8c037f60ef4245a84d36913215e079)

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 module.exports = [
-  'Safari >= 10.3',
+  'Safari >= 15.5',
   'iOS >= 10.3',
-  'Chrome >= 58',
-  'Samsung >= 11',
-  'Firefox >= 54',
-  'Edge >= 80',
-  'Android >= 58',
+  'Chrome >= 109',
+  'Samsung >= 26',
+  'Firefox >= 115.0',
+  'Edge >= 109',
+  'Android >= 109',
 ]


### PR DESCRIPTION
We can get better numbers with a lower threshold but still > 99%

```
{
  supportTable: {
    Safari: '15.5',
    Chrome: '109',
    'Samsung Internet': '26.0',
    Edge: '109',
    Firefox: '115.0',
    'Android Webview': '109'
  },
  machineFriendlySupportTable: '{"Safari":"15.5","Chrome":"109","Samsung Internet":"26.0","Edge":"109","Firefox":"115.0","Android Webview":"109"}',
  supportTableSupports: '99.076% of sessions'
}
```