### PR TITLE
Add esbuild target config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@
   ]
 ```
 
+Or if using Vite/Esbuild:
+
+```js
+import { esbuildTarget } from '@uswitch/browserslist-config'
+
+...
+vite: {
+    build: {
+      target: esbuildTarget,
+    },
+...
+```
+
 Current Support
 
 ```

--- a/index.js
+++ b/index.js
@@ -6,4 +6,16 @@ module.exports = [
   'Firefox >= 115.0',
   'Edge >= 109',
   'Android >= 109',
-]
+];
+
+// esbuild target syntax: https://esbuild.github.io/api/#target
+module.exports.esbuildTarget = [
+  'safari15.5',
+  // Esbuild does not support below es6
+  // ios10.3 does not support 'const' and requires es5
+  // ios11 is the lowest we can support for now
+  'ios11',
+  'chrome109',
+  'firefox115',
+  'edge109',
+];


### PR DESCRIPTION
Currently we only export the browserslist syntax. Many projects nowadays uses Vite which uses Esbuild under the hood. The [Esbuild target](https://esbuild.github.io/api/#target) syntax is slightly different and requires consumers to map the browserslist config onto their esbuild one, typically via [browserslist-to-esbuild](https://www.npmjs.com/package/browserslist-to-esbuild).

However, Esbuild does not support below es6, and ios@10.3 does not support `const` and requires es5. And so, for Esbuild the lowest ios version we can support is ios@11. Esbuild also doesn't support `android`.

We can forgo all the noise and extra work by simply exporting the Esbuild syntax from here.